### PR TITLE
Add dependency on Underscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "main": "./lib/superfeedr",
   "dependencies": {
-    "superfeedr": "*"
+    "superfeedr": "*",
+    "underscore": ">= 1.6.0"
   }
 }


### PR DESCRIPTION
I got an error booting Hubot because Underscore wasn't depended on
anywhere else. This adds it to `hubot-superfeedr`s dependencies so we
can guarantee its presence.
