### PR TITLE
Initialize @feeds when account is empty

### DIFF
--- a/lib/superfeedr.coffee
+++ b/lib/superfeedr.coffee
@@ -28,7 +28,7 @@ delay = (ms, func) -> setTimeout func, ms
 class HubotSuperfeedr
   client: null
   default_room: null
-  feeds: null # [] when initialized
+  feeds: []
   login: null
   password: null
   robot: null
@@ -102,7 +102,6 @@ class HubotSuperfeedr
     console.log("data: #{data}")
 
     for feed in data
-      @feeds = [] if not @feeds
       @feeds.push feed.url
 
     # Don't know if this scoping is right??


### PR DESCRIPTION
If the Superfeedr account isn't subscribed to any feeds when Hubot boots, we
get back no data and the loop in `parse_feed_callback` never runs, which left
`@feeds` uninitialized. Now we initialize it to `[]` first thing, so `feed
list` and `feed add` will work.

Fixes LeonB/hubot-superfeedr#1
